### PR TITLE
[POTATO-2] API Utils 수정 및 SESSION_ID 상수 처리

### DIFF
--- a/src/apis/common.js
+++ b/src/apis/common.js
@@ -1,66 +1,36 @@
 import axios from 'axios';
-import { AUTH_KEY } from 'constant';
+import { AUTH_KEY, SESSION_ID } from 'constant';
+import httpService from 'libs/httpService';
 import localStorageService from 'libs/localStorageService';
 
 export default {
-  send: (url, req, type = 'post') => {
-    const defaultUrl = AUTH_KEY.apiUrl;
-    url = defaultUrl + url;
-    return type === 'post' ? axios.post(url, req) : axios.get(url, req);
-  },
-
-  sendAuth: async (url, req, type = 'post') => {
-    const defaultUrl = AUTH_KEY.apiUrl;
-    url = defaultUrl + url;
-
-    const token = localStorageService.get('authToken');
-
-    if (token) {
-      return type === 'post'
-        ? axios.post(url, req, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          })
-        : axios.get(url, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          });
-    }
-
-    return type === 'post' ? axios.post(url, req) : axios.get(url, req);
-  },
-
   get: (url) => {
-    return axios.get(AUTH_KEY.apiUrl + url, {
-      headers: {
-        Authorization: `Bearer ${localStorageService.get('authToken')}`,
-      },
-    });
+    return axios.get(
+      AUTH_KEY.apiUrl + url,
+      httpService.authorization(localStorageService.get(SESSION_ID))
+    );
   },
 
   post: (url, req) => {
-    return axios.post(AUTH_KEY.apiUrl + url, req, {
-      headers: {
-        Authorization: `Bearer ${localStorageService.get('authToken')}`,
-      },
-    });
+    return axios.post(
+      AUTH_KEY.apiUrl + url,
+      req,
+      httpService.authorization(localStorageService.get(SESSION_ID))
+    );
   },
 
   put: (url, req) => {
-    return axios.put(AUTH_KEY.apiUrl + url, req, {
-      headers: {
-        Authorization: `Bearer ${localStorageService.get('authToken')}`,
-      },
-    });
+    return axios.put(
+      AUTH_KEY.apiUrl + url,
+      req,
+      httpService.authorization(localStorageService.get(SESSION_ID))
+    );
   },
 
   delete: (url) => {
-    return axios.delete(AUTH_KEY.apiUrl + url, {
-      headers: {
-        Authorization: `Bearer ${localStorageService.get('authToken')}`,
-      },
-    });
+    return axios.delete(
+      AUTH_KEY.apiUrl + url,
+      httpService.authorization(localStorageService.get(SESSION_ID))
+    );
   },
 };

--- a/src/apis/sendApi.js
+++ b/src/apis/sendApi.js
@@ -1,26 +1,23 @@
 import api from './common';
 
 export default {
-  onTest: async (req) => {
-    return await api.send('/api/test', req, 'post');
+  sendGoogleAuth: (req) => {
+    return api.post('/api/v1/auth/google', req);
   },
-  sendGoogleAuth: async (req) => {
-    return await api.send('/api/v1/auth/google', req, 'post');
+  signUpMember: (req) => {
+    return api.post('/api/v1/member', req);
   },
-  signUpMember: async (req) => {
-    return await api.send('/api/v1/member', req, 'post');
+  newBoardData: () => {
+    return api.get('/api/v2/organization/board/list?size=5');
   },
-  newBoardData: async (req) => {
-    return await api.send('/api/v2/organization/board/list?size=5', req, 'get');
+  getMajors: () => {
+    return api.get('/api/v1/major/list');
   },
-  getMajors: async (req) => {
-    return await api.send('/api/v1/major/list', req, 'get');
+  makeGroup: (req) => {
+    return api.post('/api/v1/organization', req);
   },
-  makeGroup: async (req) => {
-    return await api.sendAuth('/api/v1/organization', req, 'post');
-  },
-  getNewGroupList: async (req) => {
-    return await api.send('/api/v1/organization/list?size=3', req, 'get');
+  getNewGroupList: () => {
+    return api.get('/api/v1/organization/list?size=3');
   },
   getMyProfile: () => {
     return api.get('/api/v1/member');

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -1,2 +1,3 @@
 export { AUTH_KEY } from './authkey';
 export { GOOGLE_AUTH_QUERY, GOOGLE_AUTH_URL } from './google';
+export { SESSION_ID } from './session';

--- a/src/constant/session.js
+++ b/src/constant/session.js
@@ -1,0 +1,1 @@
+export const SESSION_ID = 'SESSION_ID';

--- a/src/libs/httpService.js
+++ b/src/libs/httpService.js
@@ -1,0 +1,9 @@
+export default {
+  authorization: (token) => {
+    return {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    };
+  },
+};

--- a/src/page/google/GoogleCallback.jsx
+++ b/src/page/google/GoogleCallback.jsx
@@ -4,7 +4,7 @@ import querystring from 'querystring';
 import { useDispatch } from 'react-redux';
 import * as actions from 'store/modules/user';
 import sendApi from 'apis/sendApi';
-import { AUTH_KEY } from 'constant';
+import { AUTH_KEY, SESSION_ID } from 'constant';
 import localStorageService from 'libs/localStorageService';
 import { Loading } from 'components/Loading';
 
@@ -22,14 +22,13 @@ const GoogleCallback = () => {
       const { email, name, profileUrl, token, type } = data.data;
 
       if (type === 'LOGIN') {
-        // TODO 상수로 빼기
-        localStorageService.set('authToken', token);
+        localStorageService.set(SESSION_ID, token);
         history.push('/Main');
         return;
       }
 
       dispatch(actions.changeUserInfo(email, name, profileUrl));
-      localStorageService.delete('authToken');
+      localStorageService.delete(SESSION_ID);
       history.push('/SignUp');
     } catch (error) {
       alert(error.response.data.message);

--- a/src/page/signUp/SignUpBody.jsx
+++ b/src/page/signUp/SignUpBody.jsx
@@ -5,6 +5,7 @@ import sendApi from 'apis/sendApi';
 import { useHistory } from 'react-router-dom';
 import localStorageService from 'libs/localStorageService';
 import * as actions from 'store/modules/user';
+import { SESSION_ID } from 'constant';
 
 const InputWrapper = styled.form`
   display: flex;
@@ -145,7 +146,7 @@ const SignUpBody = () => {
 
       const { data } = await sendApi.signUpMember(ans);
 
-      localStorageService.set('authToken', data.data);
+      localStorageService.set(SESSION_ID, data.data);
       history.push('/Main');
     } catch (error) {
       alert(error.response.data.message);


### PR DESCRIPTION
- [x] 기존의 send() 사용 코드들 변경된 common.js로 이전
- [x] SESSION_ID 상수 처리

common.js
```js
export default {
  get: (url) => {
    return axios.get(
      AUTH_KEY.apiUrl + url,
      httpService.authorization(localStorageService.get(SESSION_ID))
    );
  },

  post: (url, req) => {
    return axios.post(
      AUTH_KEY.apiUrl + url,
      req,
      httpService.authorization(localStorageService.get(SESSION_ID))
    );
  },

  put: (url, req) => {
    return axios.put(
      AUTH_KEY.apiUrl + url,
      req,
      httpService.authorization(localStorageService.get(SESSION_ID))
    );
  },

  delete: (url) => {
    return axios.delete(
      AUTH_KEY.apiUrl + url,
      httpService.authorization(localStorageService.get(SESSION_ID))
    );
  },
};

```


sendApi.js
```js
import api from './common';

export default {
  sendGoogleAuth: (req) => {
    return api.post('/api/v1/auth/google', req);
  },
  signUpMember: (req) => {
    return api.post('/api/v1/member', req);
  },
  newBoardData: () => {
    return api.get('/api/v2/organization/board/list?size=5');
  },
  getMajors: () => {
    return api.get('/api/v1/major/list');
  },
  makeGroup: (req) => {
    return api.post('/api/v1/organization', req);
  },
  getNewGroupList: () => {
    return api.get('/api/v1/organization/list?size=3');
  },
  getMyProfile: () => {
    return api.get('/api/v1/member');
  },
};


```