### PR TITLE
게시물 검색 페이지 - 게시물 상세보기 페이지 연결

### DIFF
--- a/src/page/main/BoardSearch.jsx
+++ b/src/page/main/BoardSearch.jsx
@@ -70,7 +70,7 @@ const BoardSearchItemWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  margin: 144px;
+  margin: 32px 144px 144px;
   float: left;
 `;
 
@@ -78,7 +78,7 @@ const BoardSearchItem = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: flex-start;
 `;
 
 const ItemDetail = styled.div`
@@ -212,6 +212,7 @@ const BoardSearch = () => {
           {searchItem.length ? (
             searchItem.map((data) => (
               <BoardThumbnail
+                link={`/board/${data.boardId}`}
                 boardImageUrl={getMainPicture(data.imageUrls)}
                 boardTitle={data.boardTitle}
                 orgName={data.orgName}


### PR DESCRIPTION
해시태그 부분과 게시글 목록 부분 거리가 좀 큰 것 같아서 그 부분 조금 줄였고,
게시글 썸네일 마지막 목록이 가운데 정렬되는 부분도 수정하였습니다!